### PR TITLE
Get rid of 'subroutine redefined' warnings; also use strict + warnings where missing

### DIFF
--- a/lib/HTML/Perlinfo.pm
+++ b/lib/HTML/Perlinfo.pm
@@ -1,12 +1,12 @@
 package HTML::Perlinfo;
-BEGIN { %Seen = %INC }
+BEGIN { %HTML::Perlinfo::Seen = %INC }
 
 use strict;
 use warnings;
-use Carp (); 
+use Carp ();
 
 use HTML::Perlinfo::Apache;
-use HTML::Perlinfo::Modules; 
+use HTML::Perlinfo::Modules;
 use HTML::Perlinfo::Common;
 
 use base qw(Exporter HTML::Perlinfo::Base);
@@ -17,23 +17,25 @@ our $VERSION = '1.64';
 sub perlinfo {
   my ($opt) = @_;
   $opt = 'INFO_ALL' unless $opt;
- 
+
   error_msg("Invalid perlinfo() parameter: @_")
-  if (($opt !~ /^INFO_(?:ALL|GENERAL|CONFIG|VARIABLES|APACHE|MODULES|LICENSE|LOADED)$/) || @_ > 1); 
- 
+  if (($opt !~ /^INFO_(?:ALL|GENERAL|CONFIG|VARIABLES|APACHE|MODULES|LICENSE|LOADED)$/) || @_ > 1);
+
   $opt = lc $opt;
   my $p = HTML::Perlinfo->new();
   $p->$opt;
 
 }
-%INC = %HTML::Perlinfo::Seen;
+foreach my $key (%HTML::Perlinfo::Seen) {
+    $INC{$key} = $HTML::Perlinfo::Seen{$key} unless exists $INC{$key};
+}
 1;
 __END__
 =pod
 
 =head1 NAME
 
-HTML::Perlinfo - Display a lot of Perl information in HTML format 
+HTML::Perlinfo - Display a lot of Perl information in HTML format
 
 =head1 SYNOPSIS
 

--- a/lib/HTML/Perlinfo/Common.pm
+++ b/lib/HTML/Perlinfo/Common.pm
@@ -1,4 +1,6 @@
 package HTML::Perlinfo::Common;
+use strict;
+use warnings;
 
 our @ISA = qw(Exporter);
 our @EXPORT = qw(initialize_globals print_table_colspan_header print_table_row print_table_color_start print_table_color_end print_color_box print_table_row_color print_table_start print_table_end print_box_start print_box_end print_hr print_table_header print_section print_license add_link check_path check_args check_module_args perl_version release_date process_args error_msg match_string);
@@ -145,7 +147,7 @@ sub perl_version {
 sub release_date {
 
 # when things escaped
-  %released = (
+  my %released = (
     5.000    => '1994-10-17',
     5.001    => '1995-03-14',
     5.002    => '1996-02-96',
@@ -251,9 +253,9 @@ sub process_args {
     while(my($key, $value) = splice @_, 0, 2) {
         $sub->($key, $value);
         if (exists $params{$key}){
-           @key_value = ref(${$params{$key}}[0]) eq 'ARRAY' ? @{$params{$key}} : $params{$key};
+           my @key_value = ref(${$params{$key}}[0]) eq 'ARRAY' ? @{$params{$key}} : $params{$key};
            push @key_value,$value;
-           $new_val = [@key_value];
+           my $new_val = [@key_value];
            $params{$key} = $new_val;
         }
         else {
@@ -283,7 +285,7 @@ sub  print_table_colspan_header {
 	  my $num_cols = $_[0];
 	  my $HTML = "<tr>";
 
-	  for ($i=0; $i<$num_cols; $i++) {
+	  for (my $i=0; $i<$num_cols; $i++) {
 
 		  $HTML .= sprintf("<td class=\"%s\">", ($i==0 ? "e" : "v" ));
 
@@ -340,7 +342,7 @@ sub  print_table_colspan_header {
   	  my $num_cols = $_[0];
           my $HTML = $_[1] ? "<tr bgcolor=\"$_[1]\">" : "<tr>";
 
-          for ($i=0; $i<$num_cols; $i++) {
+          for (my $i=0; $i<$num_cols; $i++) {
 
                   $HTML .= $_[1] ? "<td bgcolor=\"$_[1]\">" : sprintf("<td class=\"%s\">", ($i==0 ? "e" : "v" ));
 

--- a/lib/HTML/Perlinfo/Loaded.pm
+++ b/lib/HTML/Perlinfo/Loaded.pm
@@ -1,16 +1,20 @@
 package HTML::Perlinfo::Loaded;
-BEGIN { %Seen = %INC } 
+BEGIN { %HTML::Perlinfo::Loaded::Seen = %INC }
+use strict;
+use warnings;
 
 use HTML::Perlinfo::Modules;
 
 $VERSION = '1.02';
 
-%INC = %Seen;
-END { 
- 
+foreach my $key (%HTML::Perlinfo::Loaded::Seen) {
+    $INC{$key} = $HTML::Perlinfo::Loaded::Seen{$key} unless exists $INC{$key};
+}
+END {
+
     delete $INC{'HTML/Perlinfo/Loaded.pm'};	
     my $m = HTML::Perlinfo::Modules->new(full_page=>0, title=>'perlinfo(INFO_LOADED)');
-    $m->print_htmlhead; 
+    $m->print_htmlhead;
     $m->print_modules('files_in'=>[values %INC],'section'=>'Loaded Modules');
     print $m->info_variables,"</div></body></html>";
 }

--- a/lib/HTML/Perlinfo/Modules.pm
+++ b/lib/HTML/Perlinfo/Modules.pm
@@ -1,6 +1,7 @@
 package HTML::Perlinfo::Modules;
 
 use strict;
+use warnings;
 use File::Find;
 use File::Spec;
 use Carp ();


### PR DESCRIPTION
This patch gets rid of the "subroutine xxx redefined at..." warnings for some common modules, fixing issue #1.

Also, I added "use strict" and "use warnings" to packages where those were missing, and made the subsequent necessary changes to prevent compilation errors because of unitialized variables.
